### PR TITLE
General severity level is changed to ERROR and updates

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -185,7 +185,7 @@
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">
-            <property name="option" value="NL"/>
+            <property name="option" value="EOL"/>
             <property name="tokens"
                       value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, QUESTION, SL, SR, STAR "/>
         </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -19,8 +19,7 @@
 <module name="Checker">
     <property name="charset" value="UTF-8"/>
 
-    <!-- TODO: В перспективе должно быть ERROR -->
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java"/>
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -29,6 +29,11 @@
         <property name="ignoreLines" value="4,5,6,7,8,9,10,11,12,13"/>
     </module>
 
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^ *\* *[^ ]+$|^package.*|^import.*"/>
+    </module>
+
 <!--
     <module name="RegexpHeader">
         <property name="header" value="" />
@@ -156,10 +161,6 @@
 
         <!-- Checks for Size Violations. -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <property name="ignorePattern" value="^ *\* *[^ ]+$|^package.*|^import.*"/>
-        </module>
         <module name="MethodLength">
             <property name="max" value="50"/>
         </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -61,6 +61,9 @@
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test, Bean, ApiOperation, ExceptionHandler, ApiModelProperty"/>
         </module>
+        <module name="MissingJavadocMethod">
+            <property name="minLineCount" value="2"/>
+        </module>
         <module name="JavadocType">
             <property name="allowedAnnotations" value="SpringBootApplication, Configuration, Bean, ApiModel"/>
         </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -59,7 +59,6 @@
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test, Bean, ApiOperation, ExceptionHandler, ApiModelProperty"/>
         </module>
         <module name="JavadocType">

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -58,7 +58,6 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test, Bean, ApiOperation, ExceptionHandler, ApiModelProperty"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -61,7 +61,6 @@
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test, Bean, ApiOperation, ExceptionHandler, ApiModelProperty"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="JavadocType">
             <property name="allowedAnnotations" value="SpringBootApplication, Configuration, Bean, ApiModel"/>


### PR DESCRIPTION
Resolves #3 

- General severity level is changed to `Error` to be used in CI/CD pipelines
- Xml file is updated to comply with Checkstyle's changes